### PR TITLE
commented out github logo in corner

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -54,14 +54,14 @@ function Navigation() {
             </Navbar.Collapse>
           </Navbar>
         </Container>
-        <GithubCorner
+        {/* <GithubCorner
           href="https://github.com/cmubtg/btg-website"
           bannerColor="#ff2f44"
           octoColor="#fff"
           size={60}
           direction="left"
           target="_blank"
-        />
+        /> */}
       </div>
     </div>
   );


### PR DESCRIPTION
**Context:** The GitHub logo link in the top left corner of the website was unnecessary as it shows in the footer and was wanted removed by the BTG exec board.

**Description: ** Since we want it removed, the code for the corner logo was commented out from the navigation bar code.

**Files Changed:** 
components/Navigation.js - commented out the "Github Corner" code

<img width="1512" height="105" alt="Screenshot 2025-09-11 at 12 38 50 PM" src="https://github.com/user-attachments/assets/ee621ad0-0a0f-4170-a9df-b5ec6d46f8db" />
